### PR TITLE
Remove unused protobuf dependency

### DIFF
--- a/custom_components/gtfs_rt/manifest.json
+++ b/custom_components/gtfs_rt/manifest.json
@@ -4,9 +4,8 @@
     "documentation": "https://github.com/zacs/ha-gtfs-rt",
     "dependencies": [],
     "codeowners": ["@zacs"],
-    "version": "1.0.0",
+    "version": "1.0.1",
     "requirements": [
-        "gtfs-realtime-bindings==0.0.5",
-        "protobuf==3.6.1"
+        "gtfs-realtime-bindings==0.0.5"
     ]
 }

--- a/custom_components/gtfs_rt/sensor.py
+++ b/custom_components/gtfs_rt/sensor.py
@@ -13,11 +13,6 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = [
-    'gtfs-realtime-bindings==0.0.5',
-    'protobuf==3.6.1'
-]
-
 ATTR_STOP_ID = "Stop ID"
 ATTR_ROUTE = "Route"
 ATTR_DUE_IN = "Due in"


### PR DESCRIPTION
- This integration doesn't use protobuf directly and `gtfs-realtime-bindings` already depends on it.
- Having it causes compatibility issues with other custom integrations because Protobuf 3.6.1 is quite old: https://github.com/leikoilja/ha-google-home/issues/290
- Requirements should be only specified in `manifest.json` in modern HA versions.