### PR TITLE
Next Bus Due In Attribute

### DIFF
--- a/custom_components/gtfs_rt/sensor.py
+++ b/custom_components/gtfs_rt/sensor.py
@@ -18,6 +18,7 @@ ATTR_ROUTE = "Route"
 ATTR_DUE_IN = "Due in"
 ATTR_DUE_AT = "Due at"
 ATTR_NEXT_UP = "Next bus"
+ATTR_NEXT_UP_DUE_IN = "Next bus due in"
 
 CONF_API_KEY = 'api_key'
 CONF_X_API_KEY = 'x_api_key'
@@ -102,12 +103,13 @@ class PublicTransportSensor(Entity):
             ATTR_ROUTE: self._route
         }
         if len(next_buses) > 0:
-            attrs[ATTR_DUE_AT] = next_buses[0].arrival_time.strftime('%I:%M %p') if len(next_buses) > 0 else '-'
+            attrs[ATTR_DUE_AT] = next_buses[0].arrival_time.strftime(TIME_STR_FORMAT) if len(next_buses) > 0 else '-'
             if next_buses[0].position:
                 attrs[ATTR_LATITUDE] = next_buses[0].position.latitude
                 attrs[ATTR_LONGITUDE] = next_buses[0].position.longitude
         if len(next_buses) > 1:
-            attrs[ATTR_NEXT_UP] = next_buses[1].arrival_time.strftime('%I:%M %p') if len(next_buses) > 1 else '-'
+            attrs[ATTR_NEXT_UP] = next_buses[1].arrival_time.strftime(TIME_STR_FORMAT) if len(next_buses) > 1 else '-'
+            attrs[ATTR_NEXT_UP_DUE_IN] = due_in_minutes(next_buses[1].arrival_time) if len(next_buses) > 1 else '-'
         return attrs
 
     @property


### PR DESCRIPTION
Hello,

I added a "Next Bus Due In" attribute that will provide the min until the next bus assuming the a next bus is known. If not it will default to "-".

Often by Sensor state goes into the negative and the bus has already past my stop. With this attribute I can expose the minutes until the next bus arrives, just like the main state of the sensor. 

I also setup the TIME_STR_FORMAT variable to be used when specifying the time format of the arrival times. I was after 24 hour time format. This can be removed from the PR if desired. Really only after the Next Bus Due In attribute. 

Thanks,
Kyle