### PR TITLE
[BREAKING CHANGE] Add support for custom authorization headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ sensor:
 
 - platform: gtfs_rt
   trip_update_url: 'https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-bdfm'
-  apikey: <api key>
+  api_key: <api key>
   header_name: 'X-Api-Key'
   departures:
   - name: "Brooklyn F"

--- a/README.md
+++ b/README.md
@@ -17,19 +17,18 @@ local transit systems that provide gtfs feeds.
 
 ## Configuration
 
-Add the following to your `configuration.yaml` file:
+Add the following to your `configuration.yaml` file, under `sensor:` (add a section if it doesn't exist):
 
 ```yaml
 # Example entry for Austin TX
 
-sensor:
-  - platform: gtfs_rt
-    trip_update_url: 'https://data.texas.gov/download/rmk2-acnw/application%2foctet-stream'
-    vehicle_position_url: 'https://data.texas.gov/download/eiei-9rpf/application%2Foctet-stream'
-    departures:
-    - name: Downtown to airport
-      route: 100
-      stopid: 514
+- platform: gtfs_rt
+  trip_update_url: 'https://data.texas.gov/download/rmk2-acnw/application%2foctet-stream'
+  vehicle_position_url: 'https://data.texas.gov/download/eiei-9rpf/application%2Foctet-stream'
+  departures:
+  - name: Downtown to airport
+    route: 100
+    stopid: 514
 ```
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ sensor:
 - platform: gtfs_rt
   trip_update_url: 'https://api.stm.info/pub/od/gtfs-rt/ic/v2/tripUpdates'
   vehicle_position_url: 'https://api.stm.info/pub/od/gtfs-rt/ic/v2/vehiclePositions'
-  apikey: <api key>
+  api_key: <api key>
   departures:
   - name: "Bus 178"
     route: 168
@@ -60,12 +60,13 @@ sensor:
 # Example entry for NYC
 
 - platform: gtfs_rt
-    trip_update_url: 'https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-bdfm'
-    x_api_key: <api key>
-    departures:
-      - name: "Brooklyn F"
-        route: 'F'
-        stopid: 'F16S'
+  trip_update_url: 'https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-bdfm'
+  apikey: <api key>
+  header_name: 'X-Api-Key'
+  departures:
+  - name: "Brooklyn F"
+    route: 'F'
+    stopid: 'F16S'
 ```
 
 Configuration variables:
@@ -74,8 +75,7 @@ Configuration variables:
 - **vehicle_position_url** (*Optional*): Provides live bus position tracking on the home assistant map
 - **api_key** (*Optional*): If provided, this key will be sent with API
 requests in an "Authorization" header.
-- **x_api_key** (*Optional*): If provided, this key will be sent with API
-requests in an "x-api-key" header.
+- **header_name** (*Optional*): If provided, will replace the "x-api-key" header.
 - **departures** (*Required*): A list of routes and departure locations to watch
 - **route** (*Optional*): The name of the gtfs route
 - **stopid** (*Optional*): The stopid for the location you want etas for
@@ -104,7 +104,7 @@ logger:
 ```
 2. Restart HA
 3. Verify you're still having the issue
-4. File an issue in this Github Repository containing your HA log (Developer section > Info > Load Full Home Assistant Log)
+4. File an issue in this GitHub Repository containing your HA log (Developer section > Info > Load Full Home Assistant Log)
    * You can paste your log file at pastebin https://pastebin.com/ and submit a link.
    * Please include details about your setup (Pi, NUC, etc, docker?, HASSOS?)
    * The log file can also be found at `/<config_dir>/home-assistant.log`

--- a/custom_components/gtfs_rt/sensor.py
+++ b/custom_components/gtfs_rt/sensor.py
@@ -25,8 +25,7 @@ ATTR_NEXT_UP_DUE_IN = "Next bus due in"
 ATTR_NEXT_OCCUPANCY = "Next bus occupancy"
 
 CONF_API_KEY = 'api_key'
-CONF_APIKEY = 'apikey'
-CONF_X_API_KEY = 'x_api_key'
+CONF_HEADER_NAME = 'header_name'
 CONF_STOP_ID = 'stopid'
 CONF_ROUTE = 'route'
 CONF_DEPARTURES = 'departures'
@@ -43,8 +42,7 @@ TIME_STR_FORMAT = "%H:%M"
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_TRIP_UPDATE_URL): cv.string,
     vol.Optional(CONF_API_KEY): cv.string,
-    vol.Optional(CONF_X_API_KEY): cv.string,
-    vol.Optional(CONF_APIKEY): cv.string,
+    vol.Optional(CONF_HEADER_NAME): cv.string,
     vol.Optional(CONF_VEHICLE_POSITION_URL): cv.string,
     vol.Optional(CONF_DEPARTURES): [{
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
@@ -71,8 +69,8 @@ def due_in_minutes(timestamp):
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Get the Dublin public transport sensor."""
-    data = PublicTransportData(config.get(CONF_TRIP_UPDATE_URL), config.get(CONF_VEHICLE_POSITION_URL), config.get(CONF_API_KEY), config.get(CONF_X_API_KEY), config.get(CONF_APIKEY))
+    """Get the public transport sensor."""
+    data = PublicTransportData(config.get(CONF_TRIP_UPDATE_URL), config.get(CONF_VEHICLE_POSITION_URL), config.get(CONF_API_KEY), config.get(CONF_HEADER_NAME))
     sensors = []
     for departure in config.get(CONF_DEPARTURES):
         sensors.append(PublicTransportSensor(
@@ -148,16 +146,12 @@ class PublicTransportSensor(Entity):
 class PublicTransportData(object):
     """The Class for handling the data retrieval."""
 
-    def __init__(self, trip_update_url, vehicle_position_url=None, api_key=None, x_api_key=None, apikey=None):
+    def __init__(self, trip_update_url, vehicle_position_url=None, api_key=None, header_name='Authorization'):
         """Initialize the info object."""
         self._trip_update_url = trip_update_url
         self._vehicle_position_url = vehicle_position_url
         if api_key is not None:
-            self._headers = {'Authorization': api_key}
-        elif apikey is not None:
-            self._headers = {'apikey': apikey}    
-        elif x_api_key is not None:
-            self._headers = {'x-api-key': x_api_key}
+            self._headers = {header_name: api_key}
         else:
             self._headers = None
         self.info = {}


### PR DESCRIPTION
In order to support [Auckland Transport's API](https://dev-portal.at.govt.nz/docs/services/realtime/operations/580698237d6df41584d3d0c9), I need to set a custom authorization header name of `Ocp-Apim-Subscription-Key`.

**Breaking Changes**
This PR _intentionally_ removes the `apikey` and `x_api_key` parameters in favour of a simpler `api_key`/`header_name` approach. Merging this PR will break existing setups (potentially), so I'm leaving this to the repo maintainer's discretion.