### PR TITLE
Bump gtfs-realtime-bindings to 1.0.0

### DIFF
--- a/custom_components/gtfs_rt/manifest.json
+++ b/custom_components/gtfs_rt/manifest.json
@@ -6,6 +6,6 @@
     "codeowners": ["@zacs"],
     "version": "1.0.1",
     "requirements": [
-        "gtfs-realtime-bindings==0.0.5"
+        "gtfs-realtime-bindings==1.0.0"
     ]
 }


### PR DESCRIPTION
gtfs-realtime-bindings 1.0.0 contains an updated _pb2.py file which fixes issue #27

I have not tested this pull request in my local instance, however I have tested https://github.com/corneels/ha-gtfs-rt-v2 which works.