### PR TITLE
Add more departure times as attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Configuration variables:
 - **departures** (*Required*): A list of routes and departure locations to watch
 - **route** (*Optional*): The name of the gtfs route
 - **stopid** (*Optional*): The stopid for the location you want etas for
+- **max_departures** (*Optional*): The maximum number of departures to retrieve. Defaults to 2. Specify 0 for all departures.
 
 ## Screenshot
 

--- a/custom_components/gtfs_rt/sensor.py
+++ b/custom_components/gtfs_rt/sensor.py
@@ -134,6 +134,11 @@ class PublicTransportSensor(SensorEntity):
             attrs[ATTR_NEXT_UP] = next_buses[1].arrival_time.strftime(TIME_STR_FORMAT) if len(next_buses) > 1 else '-'
             attrs[ATTR_NEXT_UP_DUE_IN] = due_in_minutes(next_buses[1].arrival_time) if len(next_buses) > 1 else '-'
             attrs[ATTR_NEXT_OCCUPANCY] = next_buses[1].occupancy
+        if len(next_buses) > 2:
+            for i, bus in enumerate(next_buses[2:], start=2):
+                attrs[f"{ATTR_NEXT_UP} (+{i - 1})"] = bus.arrival_time.strftime(TIME_STR_FORMAT)
+                attrs[f"{ATTR_NEXT_UP_DUE_IN} (+{i - 1})"] = due_in_minutes(bus.arrival_time)
+                attrs[f"{ATTR_NEXT_OCCUPANCY} (+{i - 1})"] = bus.occupancy
         return attrs
 
     def update(self):


### PR DESCRIPTION
Resolves #35 

Adds the ability to save more departure times. 
By default, 2 departures are fetched as is the current behavior. If you specify the `max_departures` config param, you can fetch a specific number or 0 for all departures.

I'm not totally sold on the `(+x)` naming of the attributes, so I'm open to suggestions.

<img width="906" alt="image" src="https://github.com/zacs/ha-gtfs-rt/assets/706048/54c31110-d32e-4ec0-b2ff-1298d3faa960">
